### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Two-wire TM1637 button and LED controller library for Arduino
 paragraph=This is a TM1637 LED driver controller with key-scan interface library for Arduino.
 category=Display
 url=https://github.com/Erriez/ErriezTM1637
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format